### PR TITLE
Fix for negative pupil places

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
                     <br>
                     <p class="table-row">
                         <label for="pupil-places">Places </label>
-                        <input class="user-input" type="number" id="pupil-places" size="20">
+                        <input class="user-input" type="number" min="0" id="pupil-places" size="20">
                     </p>
                     <br>
                     <input class="button" type="submit" value="Calculate">

--- a/index.test.js
+++ b/index.test.js
@@ -17,6 +17,9 @@ describe('Suite to test behaviour of primary school calculation', () => {
     });
     test('that entering a string as the number of pupil places will return an error', () => {
         expect(schoolSizeCalculate(schoolType, "testing text")).toMatch(/Please enter the number/)
+    });
+    test('to recreate negative number of pupil places test result', () => {
+        expect(schoolSizeCalculate(schoolType, -5)).toBe(329.5)
     })
 });
 describe('Suite to test behaviour of secondary up to 16 school calculation', () => {
@@ -32,6 +35,9 @@ describe('Suite to test behaviour of secondary up to 16 school calculation', () 
     });
     test('that entering a string as the number of pupil places will return an error', () => {
         expect(schoolSizeCalculate(schoolType, "testing text")).toMatch(/Please enter the number/)
+    });
+    test('to confirm reported bug behaviour that negative pupil places returns an area smaller than the minimum school area', () => {
+        expect(schoolSizeCalculate(schoolType, -5)).toBeLessThan(1050)
     })
 });
 describe('Suite to test behaviour of secondary post 16 school calculation', () => {
@@ -47,5 +53,8 @@ describe('Suite to test behaviour of secondary post 16 school calculation', () =
     });
     test('that entering a string as the number of pupil places will return an error', () => {
         expect(schoolSizeCalculate(schoolType, "testing text")).toMatch(/Please enter the number/)
+    });
+    test('to confirm reported bug behaviour that negative pupil places returns an area smaller than the minimum school area', () => {
+        expect(schoolSizeCalculate(schoolType, -5)).toBeLessThan(1400)
     })
 });


### PR DESCRIPTION
JavaScript function schoolSizeCalculator has not been modified. Instead the html input box for entering the number of pupil places has been set to accept values of 0 and above.